### PR TITLE
リレーションの設定 #6

### DIFF
--- a/app/Http/Controllers/FoodItemController.php
+++ b/app/Http/Controllers/FoodItemController.php
@@ -8,8 +8,8 @@ use App\Models\FoodItem;
 class FoodItemController extends Controller
 {
     public function foodview(){
-        $posts=FoodItem::all();
-       return view('food_item',compact('posts'));
+        $posts=FoodItem::where('user_id', auth()->id())->get();//user_idがログインしているユーザーのidと同じFoodItemのみ取得
+       return view('food_item',compact('posts'));//食品一覧ページに表示
     }
 
     public function foodadd(){
@@ -21,8 +21,10 @@ class FoodItemController extends Controller
         $request->validate([
             'food_name' => 'required|max:20',
             'tag' => 'required|max:15',
-            'photo_url' => 'image|mimes:jpeg,png,jpg|max:2048'
+            //'photo_url' => 'image|mimes:jpeg,png,jpg|max:2048'
         ]);
+
+        $user_id = auth()->id();
 
         $fileName = time() . '.' . $request->photo_url->extension();
         $request->photo_url->storeAs('public/images', $fileName);
@@ -34,6 +36,7 @@ class FoodItemController extends Controller
         $post->best_before_date = $request->input('best_before_date');
         $post->tag = $request->input('tag');
         $post->photo_url = $fileName;
+        $post->user_id = $user_id;
         $post->save();
         // $post = FoodItem::create([
         //     'food_name' => $request->food_name,

--- a/app/Models/FoodItem.php
+++ b/app/Models/FoodItem.php
@@ -16,6 +16,12 @@ class FoodItem extends Model
         'best_before_date',
         'tag',
         'photo_url',
+        //'user_id',
 
     ];
+
+    //一つのFoodItemは一人のUserに紐づく
+    public function user(){
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -42,4 +42,9 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    //一人のUserが複数のFoodItemを持つ
+    public function fooditems(){
+        return $this->hasMany(FoodItem::class);
+    }
 }

--- a/database/migrations/2023_09_06_175922_drop_user_id_column.php
+++ b/database/migrations/2023_09_06_175922_drop_user_id_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('food_items', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('food_items', function (Blueprint $table) {
+            $table->string('user_id')->after('updated_at');
+        });
+    }
+};

--- a/database/migrations/2023_09_06_180243_add_userid_column_to_fooditems_table.php
+++ b/database/migrations/2023_09_06_180243_add_userid_column_to_fooditems_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('food_items', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('food_items', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+};


### PR DESCRIPTION
why
-ログインしているユーザーの投稿データのみを表示するため

what
‐food_itemsテーブルにuser_idカラム追加。usersテーブルのidと関連づく外部キー。
‐データが保存されない問題が起きたので、FoodItemControllerを調整(validate部分)。
‐UserModel、FoodItemModelに一人のUserが複数のFoodItemを持つようにメソッド追加。